### PR TITLE
Default param breaks spec.

### DIFF
--- a/lib/page_magic/element.rb
+++ b/lib/page_magic/element.rb
@@ -15,7 +15,7 @@ module PageMagic
       end
     end
 
-    def initialize name, parent_page_element, type=nil, selector, &block
+    def initialize name, parent_page_element, type=nil, selector=nil, &block
       if selector.is_a?(Hash)
         @selector = selector
       else


### PR DESCRIPTION
Removing default value for `selector` broke specs. If 3 arguments are provided (For example [here](https://github.com/Ladtech/page_magic/blob/master/spec/element_spec.rb#L68)) then ruby assumes the `type` argument to be defaulted to `nil` and assigns the 3rd non nil argument value `:type` to `selector`. 
