### PR TITLE
Fix Gemfile.lock to fix build

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    page_magic (2.0.9)
+    page_magic (2.0.10)
       activesupport (~> 6)
       capybara (~> 3)
 


### PR DESCRIPTION
There was an error when the build was running `bundle install`

```
/opt/hostedtoolcache/Ruby/2.7.4/x64/bin/bundle install --jobs 4
You are trying to install in deployment mode after changing
your Gemfile. Run `bundle install` elsewhere and add the
updated Gemfile.lock to version control.

If this is a development machine, remove the
/home/runner/work/page_magic/page_magic/Gemfile freeze
by running `bundle config unset deployment`.

The gemspecs for path gems changed
Took   3.50 seconds
Error: The process '/opt/hostedtoolcache/Ruby/2.7.4/x64/bin/bundle'
failed with exit code 16
```
the error suggestetd running `bundle install` elsewhere and commiting
the `Gemfile.lock` file. Doing this has done the trick and removed the
error.