### PR TITLE
Active support requirement

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    page_magic (2.0.12)
+    page_magic (2.0.13)
       activesupport (>= 6)
       capybara (~> 3)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,19 +2,18 @@ PATH
   remote: .
   specs:
     page_magic (2.0.11)
-      activesupport (~> 6)
+      activesupport (>= 6)
       capybara (~> 3)
       gem-release (~> 2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (6.1.4.4)
+    activesupport (7.0.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
@@ -104,7 +103,6 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.26)
-    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    page_magic (2.0.11)
+    page_magic (2.0.12)
       activesupport (>= 6)
       capybara (~> 3)
       gem-release (~> 2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,6 @@ PATH
     page_magic (2.0.12)
       activesupport (>= 6)
       capybara (~> 3)
-      gem-release (~> 2)
 
 GEM
   remote: https://rubygems.org/
@@ -108,6 +107,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  gem-release (~> 2)
   page_magic!
   poltergeist (~> 1)
   rake (~> 13)

--- a/lib/page_magic/version.rb
+++ b/lib/page_magic/version.rb
@@ -1,3 +1,3 @@
 module PageMagic
-  VERSION = '2.0.12'
+  VERSION = '2.0.13'
 end

--- a/lib/page_magic/version.rb
+++ b/lib/page_magic/version.rb
@@ -1,3 +1,3 @@
 module PageMagic
-  VERSION = '2.0.11'
+  VERSION = '2.0.12'
 end

--- a/page_magic.gemspec
+++ b/page_magic.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<activesupport>.freeze, [">= 6"])
   s.add_runtime_dependency(%q<capybara>.freeze, ['~> 3'])
-  s.add_runtime_dependency(%q<gem-release>.freeze, ['~> 2'])
+  s.add_development_dependency(%q<gem-release>.freeze, ['~> 2'])
   s.add_development_dependency(%q<poltergeist>.freeze, ['~> 1'])
   s.add_development_dependency(%q<rake>.freeze, ["~> 13"])
   s.add_development_dependency(%q<redcarpet>.freeze, ["~> 3"])

--- a/page_magic.gemspec
+++ b/page_magic.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = Gem::Requirement.new(">= 2.5")
   s.summary = "Framework for modeling and interacting with webpages"
 
-  s.add_runtime_dependency(%q<activesupport>.freeze, ["~> 6"])
+  s.add_runtime_dependency(%q<activesupport>.freeze, [">= 6"])
   s.add_runtime_dependency(%q<capybara>.freeze, ['~> 3'])
   s.add_runtime_dependency(%q<gem-release>.freeze, ['~> 2'])
   s.add_development_dependency(%q<poltergeist>.freeze, ['~> 1'])


### PR DESCRIPTION
The project does not need to be tied to version 6 of `ActiveSupport` exclusively. This loosens the requirement to make allow newer versions.